### PR TITLE
Replacing `os.getenv` with `os.environ.get`

### DIFF
--- a/dclist/gqlhttp.py
+++ b/dclist/gqlhttp.py
@@ -59,7 +59,7 @@ class GQLHTTPClient:
     def __init__(self, api_token, *args, **kwargs):
         self.loop = kwargs.get('loop') or asyncio.get_event_loop()
         self.token_provided = api_token is not None
-        self.__auth = 'Sdk '+ (api_token or os.getenv('DCLIST_TOKEN') or '')
+        self.__auth = 'Sdk '+ (api_token or os.environ.get('DCLIST_TOKEN') or '')
 
         self._transporter = kwargs.get('transporter') or AIOHTTPTransport(url=self.BASE, headers={'Authorization': self.__auth})
     


### PR DESCRIPTION
To use getenv it requires a module wich is not used here so I used `os.environ.get` as os has this attribute